### PR TITLE
Interpret 0 as num_cpus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/NfNitLoop/pipeliner"
 documentation = "https://docs.rs/pipeliner/"
 
 [dependencies]
-# None! :)
+num_cpus = "1.6"


### PR DESCRIPTION
Since it seems you took some pride in having no dependencies, making `num_cpus` an optional feature is easy enough.

Ref: #1