### PR TITLE
Be forward compatible with rust-lang/rust#59928

### DIFF
--- a/src/unordered.rs
+++ b/src/unordered.rs
@@ -193,5 +193,5 @@ impl<O, E> ResultTrait for Result<O, E> {
     type Err = E;
 
     #[inline]
-    fn result(self) -> Result<Self::Ok, Self::Err> { self }
+    fn result(self) -> Result<O, E> { self }
 }


### PR DESCRIPTION
Hello! In https://github.com/rust-lang/rust/pull/59928 we are making https://github.com/rust-lang/rust/issues/57644 a deny-by-default lint. To be forward compatible with that, here's a simple fix. Thank you for you understanding!